### PR TITLE
feat: auth flow com telas de login e cadastro

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,14 +10,45 @@ import * as SplashScreen from "expo-splash-screen";
 import React, { useEffect } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import "./global.css";
-import { RootStackParamList } from "./src/@types/navigation";
+import { AuthStackParamList, RootStackParamList } from "./src/@types/navigation";
+import { AuthProvider, useAuth } from "./src/contexts/AuthContext";
 import { BudgetDetails } from "./src/screens/BudgetDetails";
 import { BudgetForm } from "./src/screens/BudgetForm";
 import { Home } from "./src/screens/Home";
+import { SignIn } from "./src/screens/SignIn";
+import { SignUp } from "./src/screens/SignUp";
 
-const Stack = createNativeStackNavigator<RootStackParamList>();
+const AuthStack = createNativeStackNavigator<AuthStackParamList>();
+const AppStack = createNativeStackNavigator<RootStackParamList>();
 
 SplashScreen.preventAutoHideAsync();
+
+function AuthNavigator() {
+  return (
+    <AuthStack.Navigator screenOptions={{ headerShown: false }}>
+      <AuthStack.Screen name="SignIn" component={SignIn} />
+      <AuthStack.Screen name="SignUp" component={SignUp} />
+    </AuthStack.Navigator>
+  );
+}
+
+function AppNavigator() {
+  return (
+    <AppStack.Navigator screenOptions={{ headerShown: false }}>
+      <AppStack.Screen name="Home" component={Home} />
+      <AppStack.Screen name="BudgetForm" component={BudgetForm} />
+      <AppStack.Screen name="BudgetDetails" component={BudgetDetails} />
+    </AppStack.Navigator>
+  );
+}
+
+function Routes() {
+  const { user, isLoadingUser } = useAuth();
+
+  if (isLoadingUser) return null;
+
+  return user ? <AppNavigator /> : <AuthNavigator />;
+}
 
 export default function App() {
   const [fontsLoaded] = useFonts({
@@ -31,32 +62,16 @@ export default function App() {
     }
   }, [fontsLoaded]);
 
-  if (!fontsLoaded) {
-    return null;
-  }
+  if (!fontsLoaded) return null;
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <BottomSheetModalProvider>
-        <NavigationContainer>
-          <Stack.Navigator>
-            <Stack.Screen
-              name="Home"
-              component={Home}
-              options={{ headerShown: false }}
-            />
-            <Stack.Screen
-              name="BudgetForm"
-              component={BudgetForm}
-              options={{ headerShown: false }}
-            />
-            <Stack.Screen
-              name="BudgetDetails"
-              component={BudgetDetails}
-              options={{ headerShown: false }}
-            />
-          </Stack.Navigator>
-        </NavigationContainer>
+        <AuthProvider>
+          <NavigationContainer>
+            <Routes />
+          </NavigationContainer>
+        </AuthProvider>
       </BottomSheetModalProvider>
     </GestureHandlerRootView>
   );

--- a/src/@types/navigation.d.ts
+++ b/src/@types/navigation.d.ts
@@ -4,6 +4,11 @@ export declare global {
   }
 }
 
+export type AuthStackParamList = {
+  SignIn: undefined;
+  SignUp: undefined;
+};
+
 export type RootStackParamList = {
   Home: undefined;
   BudgetForm: { id?: string } | undefined;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,71 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { createContext, ReactNode, useContext, useEffect, useState } from "react";
+import { api } from "@/src/services/api";
+import { AUTH_TOKEN_KEY, AUTH_USER_KEY } from "@/src/storage/storageConfig";
+
+type User = {
+  id: string;
+  nome: string;
+  email: string;
+};
+
+type SignInResponse = {
+  token: string;
+  user: User;
+};
+
+type AuthContextData = {
+  user: User | null;
+  isLoadingUser: boolean;
+  signIn: (email: string, senha: string) => Promise<void>;
+  signOut: () => Promise<void>;
+};
+
+export const AuthContext = createContext<AuthContextData>({} as AuthContextData);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoadingUser, setIsLoadingUser] = useState(true);
+
+  async function signIn(email: string, senha: string) {
+    const { token, user } = await api.post<SignInResponse>("/users/login", {
+      email,
+      senha,
+    });
+    await AsyncStorage.setItem(AUTH_TOKEN_KEY, token);
+    await AsyncStorage.setItem(AUTH_USER_KEY, JSON.stringify(user));
+    setUser(user);
+  }
+
+  async function signOut() {
+    await AsyncStorage.multiRemove([AUTH_TOKEN_KEY, AUTH_USER_KEY]);
+    setUser(null);
+  }
+
+  useEffect(() => {
+    async function loadStoredUser() {
+      try {
+        const [token, userData] = await Promise.all([
+          AsyncStorage.getItem(AUTH_TOKEN_KEY),
+          AsyncStorage.getItem(AUTH_USER_KEY),
+        ]);
+        if (token && userData) {
+          setUser(JSON.parse(userData));
+        }
+      } finally {
+        setIsLoadingUser(false);
+      }
+    }
+    loadStoredUser();
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, isLoadingUser, signIn, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/screens/SignIn/index.tsx
+++ b/src/screens/SignIn/index.tsx
@@ -1,0 +1,100 @@
+import { AuthStackParamList } from "@/src/@types/navigation";
+import { Button } from "@/src/components/Button";
+import { Input } from "@/src/components/Input";
+import { useAuth } from "@/src/contexts/AuthContext";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { useNavigation } from "@react-navigation/native";
+import { useState } from "react";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+type SignInNavigation = NativeStackNavigationProp<AuthStackParamList, "SignIn">;
+
+export function SignIn() {
+  const [email, setEmail] = useState("");
+  const [senha, setSenha] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { signIn } = useAuth();
+  const navigation = useNavigation<SignInNavigation>();
+
+  async function handleSignIn() {
+    if (!email.trim() || !senha.trim()) {
+      return Alert.alert("Atenção", "Preencha e-mail e senha.");
+    }
+    try {
+      setIsLoading(true);
+      await signIn(email.trim(), senha);
+    } catch (error) {
+      Alert.alert(
+        "Erro ao entrar",
+        error instanceof Error ? error.message : "Não foi possível fazer login."
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-base-gray100">
+      <KeyboardAvoidingView
+        className="flex-1"
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      >
+        <View className="flex-1 justify-center px-6 gap-6">
+          <View className="items-center gap-1">
+            <Text className="text-title-lg font-bold text-main-purpleBase">
+              Service Budget
+            </Text>
+            <Text className="text-text-sm text-base-gray500">
+              Gerencie seus orçamentos
+            </Text>
+          </View>
+
+          <View className="gap-3">
+            <Input
+              placeholder="E-mail"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              value={email}
+              onChangeText={setEmail}
+              className="px-4"
+            />
+            <Input
+              placeholder="Senha"
+              secureTextEntry
+              value={senha}
+              onChangeText={setSenha}
+              className="px-4"
+            />
+          </View>
+
+          <Button
+            title={isLoading ? "Entrando..." : "Entrar"}
+            onPress={handleSignIn}
+            disabled={isLoading}
+          />
+
+          <TouchableOpacity
+            onPress={() => navigation.navigate("SignUp")}
+            activeOpacity={0.7}
+            className="items-center"
+          >
+            <Text className="text-text-sm text-base-gray500">
+              Não tem conta?{" "}
+              <Text className="text-main-purpleBase font-bold">Cadastre-se</Text>
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}

--- a/src/screens/SignUp/index.tsx
+++ b/src/screens/SignUp/index.tsx
@@ -1,0 +1,115 @@
+import { AuthStackParamList } from "@/src/@types/navigation";
+import { Button } from "@/src/components/Button";
+import { Input } from "@/src/components/Input";
+import { api } from "@/src/services/api";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { useNavigation } from "@react-navigation/native";
+import { useState } from "react";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+type SignUpNavigation = NativeStackNavigationProp<AuthStackParamList, "SignUp">;
+
+export function SignUp() {
+  const [nome, setNome] = useState("");
+  const [email, setEmail] = useState("");
+  const [senha, setSenha] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const navigation = useNavigation<SignUpNavigation>();
+
+  async function handleSignUp() {
+    if (!nome.trim() || !email.trim() || !senha.trim()) {
+      return Alert.alert("Atenção", "Preencha todos os campos.");
+    }
+    try {
+      setIsLoading(true);
+      await api.post("/users/register", {
+        nome: nome.trim(),
+        email: email.trim(),
+        senha,
+      });
+      Alert.alert("Conta criada!", "Faça login para continuar.", [
+        { text: "OK", onPress: () => navigation.navigate("SignIn") },
+      ]);
+    } catch (error) {
+      Alert.alert(
+        "Erro ao cadastrar",
+        error instanceof Error ? error.message : "Não foi possível criar a conta."
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-base-gray100">
+      <KeyboardAvoidingView
+        className="flex-1"
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      >
+        <View className="flex-1 justify-center px-6 gap-6">
+          <View className="items-center gap-1">
+            <Text className="text-title-lg font-bold text-main-purpleBase">
+              Criar Conta
+            </Text>
+            <Text className="text-text-sm text-base-gray500">
+              Preencha seus dados para começar
+            </Text>
+          </View>
+
+          <View className="gap-3">
+            <Input
+              placeholder="Nome"
+              autoCapitalize="words"
+              autoCorrect={false}
+              value={nome}
+              onChangeText={setNome}
+              className="px-4"
+            />
+            <Input
+              placeholder="E-mail"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              value={email}
+              onChangeText={setEmail}
+              className="px-4"
+            />
+            <Input
+              placeholder="Senha"
+              secureTextEntry
+              value={senha}
+              onChangeText={setSenha}
+              className="px-4"
+            />
+          </View>
+
+          <Button
+            title={isLoading ? "Cadastrando..." : "Cadastrar"}
+            onPress={handleSignUp}
+            disabled={isLoading}
+          />
+
+          <TouchableOpacity
+            onPress={() => navigation.goBack()}
+            activeOpacity={0.7}
+            className="items-center"
+          >
+            <Text className="text-text-sm text-base-gray500">
+              Já tem conta?{" "}
+              <Text className="text-main-purpleBase font-bold">Entrar</Text>
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,23 @@
+import { Platform } from "react-native";
+
+const BASE_URL =
+  Platform.OS === "android"
+    ? "http://10.0.2.2:3333"
+    : "http://localhost:3333";
+
+async function post<T>(path: string, body: object): Promise<T> {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.message ?? "Erro inesperado. Tente novamente.");
+  }
+
+  return response.json();
+}
+
+export const api = { post };

--- a/src/storage/storageConfig.ts
+++ b/src/storage/storageConfig.ts
@@ -1,1 +1,3 @@
 export const BUDGETS_COLLECTION = "@service-budget:budgets";
+export const AUTH_TOKEN_KEY = "@service-budget:token";
+export const AUTH_USER_KEY = "@service-budget:user";


### PR DESCRIPTION
## O que foi implementado

- **Dois stacks de navegação separados**: `AuthStack` (SignIn + SignUp) e `AppStack` (Home + BudgetForm + BudgetDetails). O app mostra um ou outro dependendo se o usuário está logado
- **`AuthContext`**: Context API para compartilhar estado de autenticação (`user`, `signIn`, `signOut`) com qualquer tela sem passar por props
- **Persistência de sessão**: token e dados do usuário salvos no AsyncStorage — o usuário continua logado ao reabrir o app
- **`api.ts`**: cliente HTTP centralizado com tratamento de URL para Android Emulator (`10.0.2.2`) e iOS Simulator (`localhost`)
- **Telas SignIn e SignUp**: reusam os componentes `Input` e `Button` existentes

## Fluxo

```
App abre → verifica token no AsyncStorage
  ├── token encontrado → AppStack (Home)
  └── sem token → AuthStack (SignIn)
                     └── pode navegar para SignUp
```

## Como testar

Credenciais de teste: `jhondoe@test.com` / `supersecret`

🤖 Generated with [Claude Code](https://claude.com/claude-code)