### PR TITLE
fix: migrar budgets para API e corrigir tela BudgetDetails

### DIFF
--- a/src/screens/BudgetDetails/index.tsx
+++ b/src/screens/BudgetDetails/index.tsx
@@ -80,6 +80,7 @@ export function BudgetDetails() {
   const discountValue = budget.discount
     ? subtotal * (budget.discount / 100)
     : 0;
+  const total = subtotal - discountValue;
 
   return (
     <SafeAreaView className="flex-1 bg-slate-50">
@@ -94,7 +95,7 @@ export function BudgetDetails() {
         <Text className="text-title-md font-bold text-center mr-20 flex-1">
           {budget.title}
         </Text>
-        <StatusBadge status="sent" />
+        <StatusBadge status={budget.status} />
       </View>
 
       <ScrollView className="flex-1 px-6 pt-6">
@@ -122,7 +123,7 @@ export function BudgetDetails() {
                 Criado em
               </Text>
               <Text className="text-text-md text-base-gray600">
-                {budget.createdAt}
+                {new Date(budget.createdAt).toLocaleDateString("pt-BR")}
               </Text>
             </View>
             <View className="w-1/2">
@@ -130,7 +131,7 @@ export function BudgetDetails() {
                 Atualizado em
               </Text>
               <Text className="text-text-md text-base-gray600">
-                {budget.updatedAt}
+                {new Date(budget.updatedAt).toLocaleDateString("pt-BR")}
               </Text>
             </View>
           </View>
@@ -205,7 +206,7 @@ export function BudgetDetails() {
                 Investimento total
               </Text>
               <Text className="text-title-sm font-bold text-base-gray600">
-                {formatCurrency(budget.totalPrice)}
+                {formatCurrency(total)}
               </Text>
             </View>
           </View>

--- a/src/storage/budget/budgetCreate.ts
+++ b/src/storage/budget/budgetCreate.ts
@@ -1,15 +1,7 @@
+import { api } from "@/src/services/api";
 import { Budget } from "@/src/types/budget";
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import { BUDGETS_COLLECTION } from "../storageConfig";
-import { budgetGetAll } from "./budgetGetAll";
 
 export async function budgetCreate(newBudget: Budget) {
-  try {
-    const storedBudgets = await budgetGetAll();
-    const storage = JSON.stringify([newBudget, ...storedBudgets]);
-
-    await AsyncStorage.setItem(BUDGETS_COLLECTION, storage);
-  } catch (error) {
-    throw error;
-  }
+  const { id, createdAt, updatedAt, ...data } = newBudget;
+  await api.post("/budgets/new-budget", data);
 }

--- a/src/storage/budget/budgetGetAll.ts
+++ b/src/storage/budget/budgetGetAll.ts
@@ -1,13 +1,7 @@
+import { api } from "@/src/services/api";
 import { Budget } from "@/src/types/budget";
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import { BUDGETS_COLLECTION } from "../storageConfig";
 
 export async function budgetGetAll(): Promise<Budget[]> {
-  try {
-    const storage = await AsyncStorage.getItem(BUDGETS_COLLECTION);
-    const budgets: Budget[] = storage ? JSON.parse(storage) : [];
-    return budgets;
-  } catch (error) {
-    throw error;
-  }
+  const response = await api.get<Budget[]>("/budgets");
+  return response.data;
 }

--- a/src/storage/budget/budgetGetById.ts
+++ b/src/storage/budget/budgetGetById.ts
@@ -1,13 +1,7 @@
+import { api } from "@/src/services/api";
 import { Budget } from "@/src/types/budget";
-import { budgetGetAll } from "./budgetGetAll";
 
 export async function budgetGetById(id: string): Promise<Budget | undefined> {
-  try {
-    const storage = await budgetGetAll();
-    const budget = storage.find((item) => item.id === id);
-
-    return budget;
-  } catch (error) {
-    throw error;
-  }
+  const response = await api.get<Budget>(`/budgets/${id}`);
+  return response.data;
 }

--- a/src/storage/budget/budgetRemove.ts
+++ b/src/storage/budget/budgetRemove.ts
@@ -1,17 +1,5 @@
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import { BUDGETS_COLLECTION } from "../storageConfig";
-import { budgetGetAll } from "./budgetGetAll";
+import { api } from "@/src/services/api";
 
 export async function budgetRemove(id: string) {
-  try {
-    const storage = await budgetGetAll();
-    const filteredStorage = storage.filter((item) => item.id !== id);
-
-    await AsyncStorage.setItem(
-      BUDGETS_COLLECTION,
-      JSON.stringify(filteredStorage),
-    );
-  } catch (error) {
-    throw error;
-  }
+  await api.delete(`/budgets/delete/${id}`);
 }

--- a/src/storage/budget/budgetUpdate.ts
+++ b/src/storage/budget/budgetUpdate.ts
@@ -1,20 +1,7 @@
+import { api } from "@/src/services/api";
 import { Budget } from "@/src/types/budget";
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import { BUDGETS_COLLECTION } from "../storageConfig";
-import { budgetGetAll } from "./budgetGetAll";
 
 export async function budgetUpdate(updatedBudget: Budget) {
-  try {
-    const storage = await budgetGetAll();
-    const updatedStorage = storage.map((item) =>
-      item.id === updatedBudget.id ? updatedBudget : item,
-    );
-
-    await AsyncStorage.setItem(
-      BUDGETS_COLLECTION,
-      JSON.stringify(updatedStorage),
-    );
-  } catch (error) {
-    throw error;
-  }
+  const { id, createdAt, updatedAt, ...data } = updatedBudget;
+  await api.patch(`/budgets/update/${id}`, data);
 }

--- a/src/storage/storageConfig.ts
+++ b/src/storage/storageConfig.ts
@@ -1,3 +1,2 @@
-export const BUDGETS_COLLECTION = "@service-budget:budgets";
 export const AUTH_TOKEN_KEY = "service-budget_token";
 export const AUTH_USER_KEY = "service-budget_user";


### PR DESCRIPTION
## Resumo

- Substitui AsyncStorage por chamadas à API REST para todas as operações de budget (`getAll`, `getById`, `create`, `update`, `remove`)
- Corrige exibição de datas (`createdAt`/`updatedAt`) convertendo ISO string para `DD/MM/YYYY`
- Corrige cálculo do **Investimento total** aplicando o desconto sobre o subtotal
- Corrige o `StatusBadge` que exibia status hardcoded `"sent"` em vez do status real do budget

Closes #48
Closes #49

## Test plan

- [x] Tela Home lista os budgets vindos da API
- [x] Tela BudgetDetails exibe datas no formato `DD/MM/YYYY`
- [x] Investimento total reflete corretamente a aplicação do desconto
- [x] StatusBadge exibe o status real do budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)