### PR TITLE
fix: corrigir navegação e tratamento de erro ao salvar budget

### DIFF
--- a/src/screens/BudgetForm/index.tsx
+++ b/src/screens/BudgetForm/index.tsx
@@ -26,7 +26,7 @@ import {
   Wallet,
 } from "lucide-react-native";
 import { useCallback, useRef, useState } from "react";
-import { ScrollView, Text, TouchableOpacity, View } from "react-native";
+import { Alert, ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import uuid from "react-native-uuid";
 
@@ -104,9 +104,12 @@ export function BudgetForm() {
         await budgetCreate(newBudget);
       }
 
-      navigation.navigate("Home");
+      navigation.goBack();
     } catch (error) {
-      console.log(error);
+      Alert.alert(
+        "Erro ao salvar",
+        error instanceof Error ? error.message : "Tente novamente.",
+      );
     }
   }
 


### PR DESCRIPTION
## Resumo

- Substitui `navigation.navigate("Home")` por `navigation.goBack()` após salvar: ao editar, volta para `BudgetDetails` que reganha foco e re-busca os dados atualizados da API; ao criar, volta para `Home` que re-lista os budgets
- Substitui `console.log` por `Alert.alert` para exibir a mensagem de erro ao usuário caso o save falhe

Closes #51

## Test plan

- [x] Alterar status de um budget, salvar e verificar que `BudgetDetails` exibe o status atualizado
- [x] Ao criar um novo budget, salvar e verificar retorno à tela `Home` com o budget na lista
- [x] Forçar erro de rede e verificar que o Alert de erro é exibido

🤖 Generated with [Claude Code](https://claude.com/claude-code)