### PR TITLE
fix: restaurar funcionalidade de editar nome na tela de Perfil

### DIFF
--- a/src/screens/Profile/index.tsx
+++ b/src/screens/Profile/index.tsx
@@ -1,10 +1,16 @@
 import { HorizontalLine } from "@/src/components/HorizontalLine";
+import { Input } from "@/src/components/Input";
 import { useAuth } from "@/src/contexts/AuthContext";
 import { api } from "@/src/services/api";
 import { colors } from "@/src/themes/colors";
+import {
+  BottomSheetModal,
+  BottomSheetView,
+  useBottomSheetModal,
+} from "@gorhom/bottom-sheet";
 import { useNavigation } from "@react-navigation/native";
-import { ChevronLeft, KeyRound, LogOut, Pencil } from "lucide-react-native";
-import { useState } from "react";
+import { ChevronLeft, KeyRound, LogOut, Pencil, X } from "lucide-react-native";
+import { useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -14,9 +20,83 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+function EditNameSheet({
+  currentName,
+  onSave,
+}: {
+  currentName: string;
+  onSave: (name: string) => Promise<void>;
+}) {
+  const { dismiss } = useBottomSheetModal();
+  const [name, setName] = useState(currentName);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSave() {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Informe um nome.");
+      return;
+    }
+    setError("");
+    setIsLoading(true);
+    try {
+      await onSave(trimmed);
+      dismiss();
+    } catch (err: any) {
+      setError(err?.message ?? "Erro ao atualizar nome.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <BottomSheetView className="p-6 pb-10 gap-4">
+      <View className="flex-row justify-between items-center mb-2">
+        <Text className="text-title-lg font-bold text-base-gray700">
+          Editar nome
+        </Text>
+        <TouchableOpacity onPress={() => dismiss()}>
+          <X size={24} color={colors.base.gray600} />
+        </TouchableOpacity>
+      </View>
+
+      <Input
+        placeholder="Novo nome"
+        className="pl-4"
+        value={name}
+        onChangeText={(v) => {
+          setName(v);
+          setError("");
+        }}
+        autoFocus
+      />
+
+      {!!error && (
+        <Text className="text-text-sm text-feedback-dangerBase">{error}</Text>
+      )}
+
+      <TouchableOpacity
+        activeOpacity={0.8}
+        onPress={handleSave}
+        disabled={isLoading}
+        className="h-12 rounded-2xl bg-main-purpleBase items-center justify-center"
+      >
+        {isLoading ? (
+          <ActivityIndicator color="#fff" />
+        ) : (
+          <Text className="text-white font-bold text-text-md">Salvar</Text>
+        )}
+      </TouchableOpacity>
+    </BottomSheetView>
+  );
+}
+
 export function Profile() {
   const navigation = useNavigation();
-  const { user, signOut } = useAuth();
+  const { user, signOut, updateUser } = useAuth();
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const snapPoints = useMemo(() => ["40%"], []);
   const [isUpdatingPassword, setIsUpdatingPassword] = useState(false);
 
   const nameInitial = user?.name?.charAt(0).toUpperCase() ?? "?";
@@ -77,6 +157,7 @@ export function Profile() {
           <TouchableOpacity
             activeOpacity={0.7}
             className="flex-row items-center gap-4 px-4 py-4"
+            onPress={() => bottomSheetRef.current?.present()}
           >
             <View className="w-10 h-10 rounded-full bg-main-purpleLight items-center justify-center">
               <Pencil size={18} color={colors.main.purpleBase} />
@@ -132,6 +213,15 @@ export function Profile() {
           </Text>
         </TouchableOpacity>
       </View>
+
+      <BottomSheetModal
+        ref={bottomSheetRef}
+        snapPoints={snapPoints}
+        handleIndicatorStyle={{ backgroundColor: colors.base.gray500 }}
+        enableDynamicSizing={false}
+      >
+        <EditNameSheet currentName={user?.name ?? ""} onSave={updateUser} />
+      </BottomSheetModal>
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Problema

O merge do PR #66 sobrescreveu o `Profile/index.tsx` com uma versão que não continha o `EditNameSheet`, introduzido pelo PR #63. Com isso, o botão 'Editar nome' parou de funcionar.

## Solução

Restaura o `EditNameSheet` e toda a lógica do bottom sheet de edição de nome, mantendo o botão 'Atualizar senha' adicionado pelo PR #66.

## Test plan

- [x] Tocar em 'Editar nome' — bottom sheet deve abrir com o nome atual preenchido
- [x] Alterar o nome e salvar — nome deve atualizar imediatamente na tela
- [x] Tocar em 'Atualizar senha' — Alert de confirmação de e-mail deve aparecer

🤖 Generated with [Claude Code](https://claude.com/claude-code)