### PR TITLE
feat: adicionar 'Esqueci minha senha' na tela de Login

### DIFF
--- a/src/screens/SignIn/index.tsx
+++ b/src/screens/SignIn/index.tsx
@@ -2,11 +2,21 @@ import { AuthStackParamList } from "@/src/@types/navigation";
 import { Button } from "@/src/components/Button";
 import { Input } from "@/src/components/Input";
 import { useAuth } from "@/src/contexts/AuthContext";
+import { api } from "@/src/services/api";
+import { colors } from "@/src/themes/colors";
+import {
+  BottomSheetModal,
+  BottomSheetView,
+  useBottomSheetModal,
+} from "@gorhom/bottom-sheet";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { X } from "lucide-react-native";
+import { useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import {
+  ActivityIndicator,
   Alert,
   KeyboardAvoidingView,
   Platform,
@@ -26,9 +36,88 @@ type SignInFormData = z.infer<typeof signInSchema>;
 
 type SignInNavigation = NativeStackNavigationProp<AuthStackParamList, "SignIn">;
 
+function ForgotPasswordSheet() {
+  const { dismiss } = useBottomSheetModal();
+  const [email, setEmail] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit() {
+    const trimmed = email.trim();
+    if (!trimmed) {
+      setError("Informe seu e-mail.");
+      return;
+    }
+    setError("");
+    setIsLoading(true);
+    try {
+      await api.post("/user/forgot-password", { email: trimmed });
+      dismiss();
+      Alert.alert(
+        "E-mail enviado",
+        "Um e-mail foi enviado para você com as instruções para recuperar a senha.",
+      );
+    } catch (err: any) {
+      setError(err?.message ?? "Não foi possível enviar o e-mail. Tente novamente.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <BottomSheetView className="p-6 pb-10 gap-4">
+      <View className="flex-row justify-between items-center mb-2">
+        <Text className="text-title-lg font-bold text-base-gray700">
+          Esqueci minha senha
+        </Text>
+        <TouchableOpacity onPress={() => dismiss()}>
+          <X size={24} color={colors.base.gray600} />
+        </TouchableOpacity>
+      </View>
+
+      <Text className="text-text-sm text-base-gray500">
+        Informe seu e-mail para receber o link de redefinição de senha.
+      </Text>
+
+      <Input
+        placeholder="E-mail"
+        keyboardType="email-address"
+        autoCapitalize="none"
+        autoCorrect={false}
+        className="px-4"
+        value={email}
+        onChangeText={(v) => {
+          setEmail(v);
+          setError("");
+        }}
+        autoFocus
+      />
+
+      {!!error && (
+        <Text className="text-text-sm text-feedback-dangerBase">{error}</Text>
+      )}
+
+      <TouchableOpacity
+        activeOpacity={0.8}
+        onPress={handleSubmit}
+        disabled={isLoading}
+        className="h-12 rounded-2xl bg-main-purpleBase items-center justify-center"
+      >
+        {isLoading ? (
+          <ActivityIndicator color="#fff" />
+        ) : (
+          <Text className="text-white font-bold text-text-md">Enviar</Text>
+        )}
+      </TouchableOpacity>
+    </BottomSheetView>
+  );
+}
+
 export function SignIn() {
   const { signIn } = useAuth();
   const navigation = useNavigation<SignInNavigation>();
+  const forgotPasswordRef = useRef<BottomSheetModal>(null);
+  const snapPoints = useMemo(() => ["50%"], []);
 
   const {
     control,
@@ -120,6 +209,16 @@ export function SignIn() {
           />
 
           <TouchableOpacity
+            onPress={() => forgotPasswordRef.current?.present()}
+            activeOpacity={0.7}
+            className="items-center"
+          >
+            <Text className="text-text-sm text-main-purpleBase font-bold">
+              Esqueci minha senha
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
             onPress={() => navigation.navigate("SignUp")}
             activeOpacity={0.7}
             className="items-center"
@@ -131,6 +230,15 @@ export function SignIn() {
           </TouchableOpacity>
         </View>
       </KeyboardAvoidingView>
+
+      <BottomSheetModal
+        ref={forgotPasswordRef}
+        snapPoints={snapPoints}
+        handleIndicatorStyle={{ backgroundColor: colors.base.gray500 }}
+        enableDynamicSizing={false}
+      >
+        <ForgotPasswordSheet />
+      </BottomSheetModal>
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Summary

- Adiciona link 'Esqueci minha senha' entre o botão 'Entrar' e o link 'Cadastre-se'
- Abre um bottom sheet com input de e-mail e botão 'Enviar'
- Chama `POST /user/forgot-password` com o e-mail informado
- Exibe Alert de confirmação: _"Um e-mail foi enviado para você com as instruções para recuperar a senha."_
- Erros da API são exibidos inline no bottom sheet

Closes #65

## Test plan

- [x] Tocar em 'Esqueci minha senha' — bottom sheet deve abrir
- [x] Tentar enviar com campo vazio — deve exibir mensagem de erro inline
- [x] Preencher e-mail e tocar em 'Enviar' — Alert de confirmação deve aparecer
- [x] Simular erro de API — mensagem de erro deve aparecer no bottom sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)