### PR TITLE
feat: tela de redefinição de senha via deep link

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as ExpoLinking from "expo-linking";
 import * as SplashScreen from "expo-splash-screen";
 import React, { useEffect } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
@@ -17,8 +18,18 @@ import { BudgetDetails } from "./src/screens/BudgetDetails";
 import { BudgetForm } from "./src/screens/BudgetForm";
 import { Home } from "./src/screens/Home";
 import { Profile } from "./src/screens/Profile";
+import { ResetPassword } from "./src/screens/ResetPassword";
 import { SignIn } from "./src/screens/SignIn";
 import { SignUp } from "./src/screens/SignUp";
+
+const linking = {
+  prefixes: [ExpoLinking.createURL("/")],
+  config: {
+    screens: {
+      ResetPassword: "reset-password",
+    },
+  },
+};
 
 const queryClient = new QueryClient();
 
@@ -32,6 +43,7 @@ function AuthNavigator() {
     <AuthStack.Navigator screenOptions={{ headerShown: false }}>
       <AuthStack.Screen name="SignIn" component={SignIn} />
       <AuthStack.Screen name="SignUp" component={SignUp} />
+      <AuthStack.Screen name="ResetPassword" component={ResetPassword} />
     </AuthStack.Navigator>
   );
 }
@@ -43,6 +55,7 @@ function AppNavigator() {
       <AppStack.Screen name="BudgetForm" component={BudgetForm} />
       <AppStack.Screen name="BudgetDetails" component={BudgetDetails} />
       <AppStack.Screen name="Profile" component={Profile} />
+      <AppStack.Screen name="ResetPassword" component={ResetPassword} />
     </AppStack.Navigator>
   );
 }
@@ -74,7 +87,7 @@ export default function App() {
       <GestureHandlerRootView style={{ flex: 1 }}>
         <BottomSheetModalProvider>
           <AuthProvider>
-            <NavigationContainer>
+            <NavigationContainer linking={linking}>
               <Routes />
             </NavigationContainer>
           </AuthProvider>

--- a/src/@types/navigation.d.ts
+++ b/src/@types/navigation.d.ts
@@ -8,6 +8,7 @@ export declare global {
 export type AuthStackParamList = {
   SignIn: undefined;
   SignUp: undefined;
+  ResetPassword: { token: string };
 };
 
 export type RootStackParamList = {
@@ -15,4 +16,5 @@ export type RootStackParamList = {
   BudgetForm: { id?: string } | undefined;
   BudgetDetails: { id?: string } | undefined;
   Profile: undefined;
+  ResetPassword: { token: string };
 };

--- a/src/screens/ResetPassword/index.tsx
+++ b/src/screens/ResetPassword/index.tsx
@@ -1,0 +1,148 @@
+import { AuthStackParamList } from "@/src/@types/navigation";
+import { Input } from "@/src/components/Input";
+import { useAuth } from "@/src/contexts/AuthContext";
+import { api } from "@/src/services/api";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CommonActions, RouteProp, useNavigation, useRoute } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { Controller, useForm } from "react-hook-form";
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { z } from "zod";
+
+const schema = z
+  .object({
+    password: z.string().min(8, "Mínimo 8 caracteres"),
+    confirmPassword: z.string().min(1, "Confirme a senha"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "As senhas não coincidem",
+    path: ["confirmPassword"],
+  });
+
+type FormData = z.infer<typeof schema>;
+type Navigation = NativeStackNavigationProp<AuthStackParamList, "ResetPassword">;
+type Route = RouteProp<AuthStackParamList, "ResetPassword">;
+
+export function ResetPassword() {
+  const navigation = useNavigation<Navigation>();
+  const { params } = useRoute<Route>();
+  const { user, signOut } = useAuth();
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+  async function handleReset({ password }: FormData) {
+    try {
+      await api.post("/user/reset-password", { token: params.token, password, confirmPassword: password });
+      if (user) {
+        signOut();
+      } else {
+        navigation.dispatch(
+          CommonActions.reset({ index: 0, routes: [{ name: "SignIn" }] }),
+        );
+      }
+    } catch (error) {
+      Alert.alert(
+        "Erro",
+        error instanceof Error
+          ? error.message
+          : "Não foi possível redefinir a senha.",
+      );
+    }
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-base-gray100">
+      <KeyboardAvoidingView
+        className="flex-1"
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      >
+        <View className="flex-1 justify-center px-6 gap-6">
+          <View className="items-center gap-1">
+            <Text className="text-title-lg font-bold text-main-purpleBase">
+              Redefinir senha
+            </Text>
+            <Text className="text-text-sm text-base-gray500 text-center">
+              Escolha uma nova senha para sua conta
+            </Text>
+          </View>
+
+          <View className="gap-3">
+            <View className="gap-1">
+              <Controller
+                control={control}
+                name="password"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <Input
+                    placeholder="Nova senha"
+                    secureTextEntry
+                    value={value}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    className="px-4"
+                  />
+                )}
+              />
+              {errors.password && (
+                <Text className="text-text-xs text-red-500 px-1">
+                  {errors.password.message}
+                </Text>
+              )}
+            </View>
+
+            <View className="gap-1">
+              <Controller
+                control={control}
+                name="confirmPassword"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <Input
+                    placeholder="Confirmar senha"
+                    secureTextEntry
+                    value={value}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    className="px-4"
+                  />
+                )}
+              />
+              {errors.confirmPassword && (
+                <Text className="text-text-xs text-red-500 px-1">
+                  {errors.confirmPassword.message}
+                </Text>
+              )}
+            </View>
+          </View>
+
+          <TouchableOpacity
+            activeOpacity={0.8}
+            onPress={handleSubmit(handleReset)}
+            disabled={isSubmitting}
+            className="h-12 rounded-2xl bg-main-purpleBase items-center justify-center"
+          >
+            {isSubmitting ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text className="text-white font-bold text-text-md">
+                Redefinir senha
+              </Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -16,6 +16,8 @@ const API_ERROR_MESSAGES: Record<string, string> = {
   "Email already exists": "E-mail já cadastrado.",
   "User already exists": "Usuário já cadastrado.",
   "Budget not found": "Orçamento não encontrado.",
+  "Invalid token": "Token inválido ou expirado.",
+  "Token expired": "Token inválido ou expirado.",
   Unauthorized: "Não autorizado.",
 };
 


### PR DESCRIPTION
## Resumo

- Cria a tela `ResetPassword` com campos `password` e `confirmPassword`, validados com zod (mín. 8 chars, senhas devem coincidir)
- Configura deep link `servicebudget://reset-password?token=<TOKEN>` via `expo-linking` no `NavigationContainer`
- Registra a tela em ambos os navigators (auth e app) para garantir que o deep link funcione independente do estado de autenticação
- Chama `POST /user/reset-password` com `{ token, password, confirmPassword }` no submit
- Redireciona automaticamente para `SignIn` após sucesso; se o usuário estiver logado, faz `signOut` e o `Routes` cuida do redirecionamento
- Adiciona mensagens de erro traduzidas para token inválido/expirado em `api.ts`

## Plano de teste

- [ ] Abrir deep link via `xcrun simctl openurl booted 'servicebudget://reset-password?token=<TOKEN>'` com o app fechado (cold start)
- [ ] Abrir deep link com o app já aberto e deslogado
- [ ] Tentar submeter senhas diferentes e confirmar erro inline sem chamada à API
- [ ] Submeter com senha válida e verificar redirecionamento automático para Login
- [ ] Submeter com token expirado/inválido e verificar mensagem de erro

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)