### PR TITLE
test: adicionar testes de criação de budget e serviços (closes #72)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
   },
   transformIgnorePatterns: [
-    "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|nativewind|tailwind-merge|clsx)",
+    "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|nativewind|tailwind-merge|clsx|@faker-js/faker)",
   ],
   testMatch: ["**/__tests__/**/*.test.(ts|tsx)"],
   collectCoverageFrom: ["src/**/*.{ts,tsx}", "!src/**/*.d.ts"],

--- a/src/storage/budget/__tests__/budgetCreate.test.ts
+++ b/src/storage/budget/__tests__/budgetCreate.test.ts
@@ -1,54 +1,92 @@
 import { budgetCreate } from "../budgetCreate";
 import { api } from "@/src/services/api";
-import { Budget } from "@/src/types/budget";
+import { makeBudget, makeBudgetItem } from "@/src/test/factories/budget";
 
 jest.mock("@/src/services/api");
 
 const mockedApi = api as jest.Mocked<typeof api>;
 
-const budget: Budget = {
-  id: "1",
-  client: "Cliente Teste",
-  title: "Orçamento Teste",
-  items: [
-    {
-      id: "item-1",
-      title: "Serviço A",
-      description: "Descrição do serviço",
-      quantity: 2,
-      price: 100,
-    },
-  ],
-  discount: 0,
-  status: "draft",
-  totalPrice: 200,
-  createdAt: new Date().toISOString(),
-  updatedAt: new Date().toISOString(),
-};
-
 describe("budgetCreate", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedApi.post.mockResolvedValue({ data: {} });
   });
 
-  it("chama api.post com os dados corretos", async () => {
-    mockedApi.post.mockResolvedValueOnce({ data: {} });
+  it("chama api.post no endpoint correto", async () => {
+    const budget = makeBudget();
+    await budgetCreate(budget);
+    expect(mockedApi.post).toHaveBeenCalledWith(
+      "/budgets/new-budget",
+      expect.any(Object)
+    );
+  });
 
+  it("omite id, createdAt e updatedAt do body", async () => {
+    const budget = makeBudget();
     await budgetCreate(budget);
 
-    expect(mockedApi.post).toHaveBeenCalledWith("/budgets/new-budget", {
+    const [, body] = mockedApi.post.mock.calls[0];
+    expect(body).not.toHaveProperty("id");
+    expect(body).not.toHaveProperty("createdAt");
+    expect(body).not.toHaveProperty("updatedAt");
+  });
+
+  it("envia os campos obrigatórios no body", async () => {
+    const budget = makeBudget();
+    await budgetCreate(budget);
+
+    const [, body] = mockedApi.post.mock.calls[0];
+    expect(body).toMatchObject({
       client: budget.client,
       title: budget.title,
       items: budget.items,
-      discount: budget.discount,
       status: budget.status,
       totalPrice: budget.totalPrice,
     });
   });
 
-  it("propaga erro da API", async () => {
-    mockedApi.post.mockRejectedValueOnce(new Error("Erro de rede"));
+  it("envia status 'draft' para novos orçamentos", async () => {
+    const budget = makeBudget({ status: "draft" });
+    await budgetCreate(budget);
 
+    const [, body] = mockedApi.post.mock.calls[0];
+    expect(body.status).toBe("draft");
+  });
+
+  it("envia os itens de serviço corretamente", async () => {
+    const items = [
+      makeBudgetItem({ quantity: 3, price: 200 }),
+      makeBudgetItem({ quantity: 1, price: 500 }),
+    ];
+    const budget = makeBudget({ items });
+    await budgetCreate(budget);
+
+    const [, body] = mockedApi.post.mock.calls[0];
+    expect(body.items).toHaveLength(2);
+    expect(body.items).toEqual(items);
+  });
+
+  it("envia desconto quando informado", async () => {
+    const budget = makeBudget({ discount: 15 });
+    await budgetCreate(budget);
+
+    const [, body] = mockedApi.post.mock.calls[0];
+    expect(body.discount).toBe(15);
+  });
+
+  it("propaga erro da API quando criação falha", async () => {
+    mockedApi.post.mockRejectedValueOnce(new Error("Erro de rede"));
+    const budget = makeBudget();
     await expect(budgetCreate(budget)).rejects.toThrow("Erro de rede");
+  });
+
+  it("propaga erro de validação do servidor", async () => {
+    mockedApi.post.mockRejectedValueOnce(
+      new Error("Client é obrigatório.")
+    );
+    const budget = makeBudget();
+    await expect(budgetCreate(budget)).rejects.toThrow(
+      "Client é obrigatório."
+    );
   });
 });

--- a/src/test/factories/budget.ts
+++ b/src/test/factories/budget.ts
@@ -1,0 +1,33 @@
+import { faker } from "@faker-js/faker";
+import { Budget, BudgetItem, BudgetStatus } from "@/src/types/budget";
+
+export function makeBudgetItem(overrides: Partial<BudgetItem> = {}): BudgetItem {
+  return {
+    id: faker.string.uuid(),
+    title: faker.commerce.productName(),
+    description: faker.commerce.productDescription(),
+    quantity: faker.number.int({ min: 1, max: 10 }),
+    price: faker.number.float({ min: 50, max: 5000, fractionDigits: 2 }),
+    ...overrides,
+  };
+}
+
+export function makeBudget(overrides: Partial<Budget> = {}): Budget {
+  const items = overrides.items ?? [makeBudgetItem(), makeBudgetItem()];
+  const totalPrice =
+    overrides.totalPrice ??
+    items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+  return {
+    id: faker.string.uuid(),
+    client: faker.person.fullName(),
+    title: faker.commerce.productName(),
+    items,
+    discount: 0,
+    status: "draft" as BudgetStatus,
+    totalPrice,
+    createdAt: faker.date.past().toISOString(),
+    updatedAt: faker.date.recent().toISOString(),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
- Cria `src/test/factories/budget.ts` com `makeBudget` e `makeBudgetItem` usando `@faker-js/faker` (reutilizável nas issues #73 e #74)
- Expande `budgetCreate.test.ts` com 8 cenários cobrindo todos os itens da issue #72
- Corrige `transformIgnorePatterns` no `jest.config.js` para suportar `@faker-js/faker` v10 (ESM)

## Cenários cobertos
- [x] Chama `api.post` no endpoint correto
- [x] Omite `id`, `createdAt` e `updatedAt` do body
- [x] Envia campos obrigatórios (`client`, `title`, `items`, `status`, `totalPrice`)
- [x] Envia status `draft` para novos orçamentos
- [x] Envia itens de serviço corretamente
- [x] Envia desconto quando informado
- [x] Propaga erro de rede
- [x] Propaga erro de validação do servidor

## Test plan
- [ ] `yarn test` passa 8 testes sem warnings

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)